### PR TITLE
Grammar fixes for the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ Yet another signify tool
 
 ## Introduction
 
-Asignify tool is heavily inspired by [signify](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/signify) used in OpenBSD.
-However, the main goal of this project is to define high level API for signing files,
-validating signatures and encrypting using public keys cryptography. 
-Asignify is designed to be portable and self-contained with zero external dependencies. It uses [blake2b](https://blake2.net/) as the hash function and ed25519 implementation from [tweetnacl](http://tweetnacl.cr.yp.to/).
+Asignify is heavily inspired by [signify](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/signify), used in OpenBSD.
+However, the main goal of this project is to define a high-level API for signing files,
+validating signatures and encrypting files using public key cryptography. 
+Asignify is designed to be portable and self-contained with zero external dependencies. It uses [blake2b](https://blake2.net/) as the hash function and the ed25519 implementation from [tweetnacl](http://tweetnacl.cr.yp.to/).
 
 Asignify can verify OpenBSD signatures (but it cannot sign messages in OpenBSD format yet).
 
-## Key features
+## Key Features
 
 - Zero dependencies (libc and C compiler are likely required though), so it could be easily used in embedded systems
 - Modern cryptography primitives (ed25519, blake2 and sha512 namely)
-- Ability to encrypt files with the same keys using curve25519 based [cryptobox](http://nacl.cr.yp.to/box.html).
-- Protecting secret keys by passwords using PBKDF2-BLAKE2 routine
+- The ability to encrypt files with the same keys using curve25519-based [cryptobox](http://nacl.cr.yp.to/box.html).
+- Protecting secret keys with passwords using PBKDF2-BLAKE2 routines
 - `asignify` can convert ssh ed25519 private keys to the native format and verify signatures using just ssh ed25519 public keys (without intermediate conversions)
-- `asignify` is designed to be fast and portable, it is faster than many state-of-art tools, for example, gpg:
+- `asignify` is designed to be fast and portable. It is faster than many state-of-art tools, for example, gpg:
 
 ```
 Intel(R) Core(TM)2 Quad CPU    Q6600  @ 2.40GHz (-O3)
@@ -27,14 +27,14 @@ asignify encrypt sec1 sec2.pub test   7,66s user 2,48s system 88% cpu 11,482 tot
 gpg --encrypt --sign -r bob@example.com test   20,61s user 0,51s system 99% cpu 21,197 total
 ```
 
-- `asignify` provides high level API for application developers for signing, verifying, encrypting and
-keys generation
-- All keys, signatures and encrypted files contain version information allowing to change
-cryptographical primitives in the future without loosing of backward compatibility.
+- `asignify` provides a high-level API to application developers for signing, verifying, encrypting and
+key generation
+- All keys, signatures and encrypted files contain version information, allowing changes to
+cryptographical primitives in the future without loss of backward compatibility.
 
-## Usage samples
+## Usage Examples
 
-Here are some (descriptive) usage examples of `asignify` utility:
+Here are some (descriptive) usage examples of the `asignify` utility:
 
 - Get help for a the tool:
 
@@ -43,75 +43,75 @@ $ asignify help
 $ asignify help <command>
 ```
 
-- Generate keypair:
+- Generate a Keypair:
 
 ```
 $ asignify generate privkey
 $ asignify generate --no-password privkey pubkey
 ```
 
-- Convert ssh key:
+- Convert an SSH Key:
 
 ```
 $ asignify generate -s sshkey privkey
 $ asignify generate --no-password -s sshkey privkey
 ```
 
-- Sign files
+- Sign Files
 
 ```
 $ asignify sign secretkey digests.sig file1 file2 ...
 ```
 
-- Verify signature on digests file 
+- Verify a Digest File's Signature 
 
 ```
 $ asignify verify publickey digests.sig
 ```
 
-- Check integrity of files correspoinding to the digests
+- Check the Integrity of Files Correspoinding to the Digests
 
 ```
 $ asignify check publickey digests.sig file1 file2 ...
 ```
 
-- Check integrity using SSH key
+- Check Integrity Using an SSH Key
 
 ```
 $ asignify check sshpubkey digests.sig file1 file2 ...
 ```
 
-- Encrypt a file using own private key and peer's public key:
+- Encrypt a File Using Your Private Key and a Peer's Public Key:
 
 ```
 $ asignify encrypt ownprivkey peerpubkey in out
 ```
 
-- Decrypt a file using peer's private key and own public key:
+- Decrypt a File Using a Peer's Private Key and Your Public Key:
 
 ```
 $ asignify decrypt peerprivkey ownpubkey in out
 $ asignify encrypt -d peerprivkey ownpubkey in out
 ```
  
-## Cryptographic basis
+## Cryptographic Basis
 
-Asignify relies on the same primitives as `signify` utility, however, for the native format
-asignify uses `blake2` cryptographic hash function instead of `sha512`. I decided this
+Asignify relies on the same primitives as the `signify` utility. However, for the native format,
+asignify uses the `blake2` cryptographic hash function instead of `sha512`. I decided this
 mainly because of the performance of `blake2`. Since this function was in the final of
 SHA3 competition (along with the current `keccak` winner), I believe that it is secure
-enough for using as collisions resistant hash function. Moreover, unlike sha2, blake2 is 
-not vulnerable to extensions attacks.
+enough for use as a collision-resistant hash function. Moreover, unlike sha2, blake2 is 
+not vulnerable to extension attacks.
 
-For digital signatures `asignify` uses `ed25519` algorithm which is blazingly fast and
-proven to be secure even without random oracle (based on Schnorr scheme). `tweetnacl` library
-is very small and precisely analysed.
+For digital signatures, `asignify` uses the `ed25519` algorithm which is blazingly fast and
+proven to be secure even without a random oracle (based on Schnorr scheme). The `tweetnacl` library
+is very small and precisely analyzed.
 
 To sign a file, `asignify` does the following steps:
 
-1. Calculates digest of a file (e.g. `blake2` or `sha512`)
-2. Opens secret key file (decrypting it if needed)
-3. Write all digests to the output buffer in format:
+1. Calculates the digest of a file (e.g. `blake2` or `sha512`)
+2. Opens the secret key file (decrypting it if needed)
+3. Write all the digests to the output buffer in format:
 
 ```
 SHA256 (filename) = deadbeef....
@@ -119,26 +119,26 @@ SIZE (filename) = 666
 ...
 ```
 
-4. Calculates ed25519 signature over using secret key and the following fields:
+4. Calculates the ed25519 signature over using secret key and the following fields:
 	- version
 	- data
-5. Afterwards, a signature is packed into `asignify` signature line and prepended
+5. Afterwards, a signature is packed into the `asignify` signature line and prepended
 to the digests content
 
-To verify signature, `asignify` loads public key, verifies the signature in the same
-way, load files digests and verify corresponding files agains these digests.
+To verify a signature, `asignify` loads the public key, verifies the signature in the same
+way, loads the files' digest(s) and verifies the corresponding files agains those digests.
 
-Hence, `asignify` only sign digests of files and not files themselves, and a signature
+Hence, `asignify` only signs digests of files and not files themselves, and a signature
 contains both digests and its ed25519 signature.
 
-## Keys storage
+## Key Storage
 
-Secret key for `asignify` can be encrypted using password-based key derivation function,
+The secret key for `asignify` can be encrypted using a password-based key derivation function,
 namely `pbkdf2-blake2`. This function can be tuned for the number of rounds to increase
-amount of work required for an adversary to brute-force the encryption password into
+amount of work required for an adversary to brute force the encryption password into
 a valid encryption key.
 
-Currently, `asignify` uses the following fields for private key:
+Currently, `asignify` uses the following fields for private keys:
 
 ~~~
 asignify-private-key
@@ -151,10 +151,10 @@ salt: <hex_blob|16 bytes>
 checksum: <hex_blob|64 bytes>
 ~~~
 
-Checksum is used to validate password against the original encryption key. The current
-minimum rounds count is 10000, however, it can be changed in future.
+The checksum is used to validate the password against the original encryption key. The current
+minimum rounds count is 10000. However, it can be changed in future.
 
-Public keys and signatures has nearly the same format:
+Public keys and signatures have nearly the same format:
 
 ~~~
 magic:version:<b64_key_id>:<b64_key_data>
@@ -162,13 +162,13 @@ asignify-pubkey:1:kEjp3MrX5fE=:Hut...bl/mQ=
 asignify-sig:1:kEjp3MrX5fE=:Sfg...A==
 ~~~
 
-Key id is used to match keypairs and the corresponding signatures.
+The key ID is used to match keypairs and the corresponding signatures.
 
 ## Libasignify API
 
-`libasignify` provides high level API for the most common signature operations.
+`libasignify` provides a high-level API for the most common signature operations.
 
-To verify a signature you should do the following:
+To verify a signature, you should do the following:
 
 ~~~C
 /* Init context */
@@ -198,7 +198,7 @@ for (i = 0; i < argc; i ++) {
 asignify_verify_free(vrf);
 ~~~
 
-To sign files, you should provide callback for password prompt (e.g. by BSD function
+To sign files, you should provide a callback for the password prompt (e.g. by BSD function
 `readpassphrase`):
 
 ~~~C
@@ -256,7 +256,7 @@ if (!asignify_sign_write_signature(sgn, sigfile)) {
 asignify_sign_free(sgn);
 ~~~
 
-Generating of keypairs is served by `libasignify` as well:
+Generation of keypairs is served by `libasignify` as well:
 
 ~~~C
 if (!asignify_generate(seckeyfile, pubkeyfile, 1, rounds,
@@ -265,24 +265,24 @@ if (!asignify_generate(seckeyfile, pubkeyfile, 1, rounds,
 }
 ~~~
 
-Specifying `NULL` as password callback leads to unencrypted secret keys being produced.
+Specifying `NULL` as a password callback leads to unencrypted secret keys being produced.
 
 
-## Supported digests format
+## Supported Digest Formats
 
 - SHA256
 - SHA512
 - BLAKE2b
 
-For sha2 `libasignify` can use openssl if it is available in the system since it
-provides highly optimized versions of SHA allowing to calculate checksums much quicker
-than sha2 code embedded into `libasignify`.
+For sha2, `libasignify` can use openssl if it is available in the system since it
+provides highly optimized versions of SHA that calculates checksums much quicker
+than the sha2 code embedded into `libasignify`.
 
-## OpenBSD signatures
+## OpenBSD Signatures
 
-`libasignify` automatically recognises and parses OpenBSD signatures and public keys allowing
-thus to verify signatures produced by `signify` utility transparently. Secret keys and signing
-is currently unsupported, however such a support is planned in the future.
+`libasignify` automatically recognises and parses OpenBSD signatures and public keys, allowing
+verification of signatures produced by the `signify` utility transparently. Secret keys and signing
+are currently unsupported, however support is planned in the future.
 
 ## Roadmap
 
@@ -292,9 +292,9 @@ is currently unsupported, however such a support is planned in the future.
 - Fuzz testing
 - ~~Encryption via ed25519 <-> curve25519 transform~~
 
-## License and authors
+## License and Authors
 
-This code is licensed under simplified BSD license and includes portions of 3-rd
+This code is licensed under simplified BSD license and includes portions of third
 party code designed and written by various authors:
 
 - blake2: 


### PR DESCRIPTION
This fixes some incorrect English in the readme while keeping it as close to the original text as possible.